### PR TITLE
Bitcoin sync serie3

### DIFF
--- a/core/lib/bigd/bigdtypes.h
+++ b/core/lib/bigd/bigdtypes.h
@@ -19,6 +19,7 @@
 
 #ifndef BIGDTYPES_H_
 #define BIGDTYPES_H_ 1
+#pragma warning (disable : 4005) // remove macro redefinition warning message
 
 #include <stddef.h>
 

--- a/core/src/utils/DateUtils.cpp
+++ b/core/src/utils/DateUtils.cpp
@@ -51,6 +51,9 @@ const std::unordered_map<std::string, std::string> MONTHS = {
     {"Dec", "12"},
 };
 
+const std::regex dateRegex1("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})[\\.\\d]*([Z]?)");
+const std::regex dateRegex2("([0-9]+)-([a-zA-Z]+)-([0-9]+) ([0-9]+):([0-9]+):([0-9]+)[\\.0-9]*([Z]?)");
+
 #if defined(_WIN32) || defined(_WIN64)
     #if defined(_MSC_VER)
         time_t timegm(struct tm* tm) { return _mkgmtime(tm); }
@@ -61,11 +64,10 @@ const std::unordered_map<std::string, std::string> MONTHS = {
 
 namespace ledger {
     namespace core {
-        std::chrono::system_clock::time_point ledger::core::DateUtils::fromJSON(const std::string &str) {
-            std::regex ex("([0-9]+)-([0-9]+)-([0-9]+)T([0-9]+):([0-9]+):([0-9]+)[\\.0-9]*([Z]?)");
+        std::chrono::system_clock::time_point ledger::core::DateUtils::fromJSON(const std::string &str) {            
             std::cmatch what;
 
-            if (regex_match(str.c_str(), what, ex)) {
+            if (regex_match(str.c_str(), what, dateRegex1)) {
                 auto year = boost::lexical_cast<unsigned int>(std::string(what[1].first, what[1].second));
                 auto month = boost::lexical_cast<unsigned int>(std::string(what[2].first, what[2].second));
                 auto day = boost::lexical_cast<unsigned int>(std::string(what[3].first, what[3].second));
@@ -100,10 +102,8 @@ namespace ledger {
     }
 
     std::string ledger::core::DateUtils::formatDateFromJSON(const std::string &str) {
-        std::regex ex("([0-9]+)-([a-zA-Z]+)-([0-9]+) ([0-9]+):([0-9]+):([0-9]+)[\\.0-9]*([Z]?)");
         std::cmatch what;
-
-        if (regex_match(str.c_str(), what, ex)) {
+        if (regex_match(str.c_str(), what, dateRegex2)) {
             auto year = boost::lexical_cast<unsigned int>(std::string(what[1].first, what[1].second));
             auto month = boost::lexical_cast<std::string>(std::string(what[2].first, what[2].second));
             auto day = boost::lexical_cast<unsigned int>(std::string(what[3].first, what[3].second));

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -623,7 +623,7 @@ namespace ledger {
             broadcastRawTransaction(transaction->serialize(), callback);
         }
 
-        std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(bool partial) {
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(std::experimental::optional<bool> partial) {
             auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
             auto getUTXO = [=]() -> Future<std::vector<BitcoinLikeUtxo>> {
                 return Future<std::vector<BitcoinLikeUtxo>>::async(getContext(), [=]() {

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.cpp
@@ -109,13 +109,13 @@ namespace ledger {
         }
 
         int BitcoinLikeAccount::putTransaction(soci::session &sql,
-                                               const BitcoinLikeBlockchainExplorerTransaction &transaction) {
+                                               const BitcoinLikeBlockchainExplorerTransaction &transaction, bool needExtendKeychain) {
             if (transaction.block.nonEmpty())
                 putBlock(sql, transaction.block.getValue());
             auto nodeIndex = std::const_pointer_cast<const BitcoinLikeKeychain>(_keychain)->getFullDerivationScheme().getPositionForLevel(DerivationSchemeLevel::NODE);
             std::list<std::pair<BitcoinLikeBlockchainExplorerInput *, DerivationPath>> accountInputs;
             std::list<std::pair<BitcoinLikeBlockchainExplorerOutput *, DerivationPath>> accountOutputs;
-            uint64_t fees = 0L;
+            uint64_t fees = transaction.fees;
             uint64_t sentAmount = 0L;
             uint64_t receivedAmount = 0L;
             std::vector<std::string> senders;
@@ -138,15 +138,12 @@ namespace ledger {
                         // This address is part of the account.
                         sentAmount += input.value.getValue().toUint64();
                         accountInputs.push_back(std::make_pair(const_cast<BitcoinLikeBlockchainExplorerInput *>(&input), DerivationPath(path.getValue())));
-                        if (_keychain->markPathAsUsed(DerivationPath(path.getValue()))) {
+                        if (_keychain->markPathAsUsed(DerivationPath(path.getValue()), needExtendKeychain)) {
                             result = result | FLAG_TRANSACTION_ON_PREVIOUSLY_EMPTY_ADDRESS;
                         } else {
                             result = result | FLAG_TRANSACTION_ON_USED_ADDRESS;
                         }
                     }
-                }
-                if (input.value.nonEmpty()) {
-                    fees += input.value.getValue().toUint64();
                 }
             }
 
@@ -171,7 +168,7 @@ namespace ledger {
                             receivedAmount += output.value.toUint64();
                             recipients.push_back(output.address.getValue());
                         }
-                        if (_keychain->markPathAsUsed(DerivationPath(path.getValue()))) {
+                        if (_keychain->markPathAsUsed(DerivationPath(path.getValue()), needExtendKeychain)) {
                             result = result | FLAG_TRANSACTION_ON_PREVIOUSLY_EMPTY_ADDRESS;
                         } else {
                             result = result | FLAG_TRANSACTION_ON_USED_ADDRESS;
@@ -180,7 +177,6 @@ namespace ledger {
                         recipients.push_back(output.address.getValue());
                     }
                 }
-                fees = fees - output.value.toUint64();
             }
             std::stringstream snds;
             strings::join(senders, snds, ",");
@@ -627,7 +623,7 @@ namespace ledger {
             broadcastRawTransaction(transaction->serialize(), callback);
         }
 
-        std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(std::experimental::optional<bool> partial) {
+        std::shared_ptr<api::BitcoinLikeTransactionBuilder> BitcoinLikeAccount::buildTransaction(bool partial) {
             auto self = std::dynamic_pointer_cast<BitcoinLikeAccount>(shared_from_this());
             auto getUTXO = [=]() -> Future<std::vector<BitcoinLikeUtxo>> {
                 return Future<std::vector<BitcoinLikeUtxo>>::async(getContext(), [=]() {

--- a/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
+++ b/core/src/wallet/bitcoin/BitcoinLikeAccount.hpp
@@ -80,7 +80,7 @@ namespace ledger {
              * @param transaction
              * @return A flag indicating if the transaction was ignored, inserted
              */
-            int putTransaction(soci::session& sql, const BitcoinLikeBlockchainExplorerTransaction& transaction);
+            int putTransaction(soci::session& sql, const BitcoinLikeBlockchainExplorerTransaction& transaction, bool needExtendKeychain=true);
             /**
              *
              * @param block

--- a/core/src/wallet/bitcoin/keychains/BitcoinLikeKeychain.cpp
+++ b/core/src/wallet/bitcoin/keychains/BitcoinLikeKeychain.cpp
@@ -84,10 +84,10 @@ namespace ledger {
             return _scheme;
         }
 
-        bool BitcoinLikeKeychain::markAsUsed(const std::string &address) {
+        bool BitcoinLikeKeychain::markAsUsed(const std::string &address, bool needExtendKeychain) {
             auto path = getAddressDerivationPath(address);
             if (path.nonEmpty()) {
-                return markPathAsUsed(DerivationPath(path.getValue()));
+                return markPathAsUsed(DerivationPath(path.getValue()), needExtendKeychain);
             } else {
                 return false;
             }

--- a/core/src/wallet/bitcoin/keychains/BitcoinLikeKeychain.hpp
+++ b/core/src/wallet/bitcoin/keychains/BitcoinLikeKeychain.hpp
@@ -65,10 +65,11 @@ namespace ledger {
                     const std::shared_ptr<Preferences>& preferences);
 
             virtual bool markAsUsed(const std::vector<std::string>& addresses);
-            virtual bool markAsUsed(const std::string& address);
-            virtual bool markPathAsUsed(const DerivationPath& path) = 0;
+            virtual bool markAsUsed(const std::string& address, bool needExtendKeychain=true);
+            virtual bool markPathAsUsed(const DerivationPath& path, bool needExtendKeychain = true) = 0;
 
             virtual std::vector<Address> getAllObservableAddresses(uint32_t from, uint32_t to)  = 0;
+            virtual std::vector<std::string> getAllObservableAddressString(uint32_t from, uint32_t to) = 0;
             virtual std::vector<Address> getAllObservableAddresses(KeyPurpose purpose, uint32_t from, uint32_t to) = 0;
 
             virtual Address getFreshAddress(KeyPurpose purpose) = 0;

--- a/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.cpp
+++ b/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.cpp
@@ -89,7 +89,7 @@ namespace ledger {
                     .value_or(api::ConfigurationDefaults::KEYCHAIN_DEFAULT_OBSERVABLE_RANGE);
         }
 
-        bool CommonBitcoinLikeKeychains::markPathAsUsed(const DerivationPath &p) {
+        bool CommonBitcoinLikeKeychains::markPathAsUsed(const DerivationPath &p, bool needExtendKeychain) {
             DerivationPath path(p);
             if (path.getParent().getLastChildNum() == 0) {
                 if (path.getLastChildNum() < _state.maxConsecutiveReceiveIndex ||
@@ -102,7 +102,9 @@ namespace ledger {
                         _state.nonConsecutiveReceiveIndexes.insert(path.getLastChildNum());
                     _state.empty = false;
                     saveState();
-                    getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
+                    if (needExtendKeychain) {
+                        getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
+                    }
                     return true;
                 }
             } else {
@@ -116,7 +118,9 @@ namespace ledger {
                         _state.nonConsecutiveChangeIndexes.insert(path.getLastChildNum());
                     _state.empty = false;
                     saveState();
-                    getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
+                    if (needExtendKeychain) {
+                        getAllObservableAddresses(path.getLastChildNum(), path.getLastChildNum() + _observableRange);
+                    }
                     return true;
                 }
             }
@@ -132,6 +136,10 @@ namespace ledger {
 
         std::vector<BitcoinLikeKeychain::Address> CommonBitcoinLikeKeychains::getAllObservableAddresses(uint32_t from, uint32_t to) {
             return deriveInBulk(from, to);
+        }
+
+        std::vector<std::string> CommonBitcoinLikeKeychains::getAllObservableAddressString(uint32_t from, uint32_t to) {
+            return deriveInBulkAddressString(from, to);
         }
 
         std::vector<BitcoinLikeKeychain::Address>
@@ -171,7 +179,8 @@ namespace ledger {
                                                             uint32_t to) {
             auto maxObservableIndex = (purpose == KeyPurpose::CHANGE ? _state.maxConsecutiveChangeIndex + _state.nonConsecutiveChangeIndexes.size() : _state.maxConsecutiveReceiveIndex + _state.nonConsecutiveReceiveIndexes.size()) + _observableRange;
             auto length = std::min<size_t >(to - from, maxObservableIndex - from);
-            std::vector<BitcoinLikeKeychain::Address> result(length +1);
+            std::vector<BitcoinLikeKeychain::Address> result;
+            result.reserve(length + 1);
             for (auto i = 0; i <= length; i++) {
                 if (purpose == KeyPurpose::RECEIVE) {
                     result.push_back(derive(KeyPurpose::RECEIVE, from + i));
@@ -270,7 +279,6 @@ namespace ledger {
             return std::dynamic_pointer_cast<BitcoinLikeAddress>(BitcoinLikeAddress::parse(address, getCurrency(), Option<std::string>(localPath)));
         }
 
-
         std::vector<BitcoinLikeKeychain::Address> CommonBitcoinLikeKeychains::deriveInBulk(uint32_t from, uint32_t to) {
             auto currency = getCurrency();
             std::vector<BitcoinLikeKeychain::Address> res;
@@ -279,29 +287,62 @@ namespace ledger {
             bool hasDBChange = false;
             for (int iPurpose : {KeyPurpose::RECEIVE, KeyPurpose::CHANGE})
             {
-                auto xpub = iPurpose == KeyPurpose::RECEIVE ? _publicNodeXpub : _internalNodeXpub;
                 for (int index = from; index <= to; index++)
                 {
                     auto localPath = getDerivationScheme()
                         .setAccountIndex(getAccountIndex())
                         .setCoinType(currency.bip44CoinType)
-                        .setNode(iPurpose)
-                        .setAddressIndex(index).getPath().toString();
-
+                        .setNode(iPurpose).setAddressIndex(index).getPath().toString();
                     auto cacheKey = fmt::format("path:{}", localPath);
                     auto address = getPreferences()->getString(cacheKey, "");
 
                     if (address.empty()) {
+                        auto xpub = iPurpose == KeyPurpose::RECEIVE ? _publicNodeXpub : _internalNodeXpub;
                         auto p = getDerivationScheme().getSchemeFrom(DerivationSchemeLevel::NODE).shift(1)
                             .setAccountIndex(getAccountIndex())
                             .setCoinType(currency.bip44CoinType)
-                            .setNode(iPurpose)
-                            .setAddressIndex(index).getPath().toString();
+                            .setNode(iPurpose).setAddressIndex(index).getPath().toString();
                         address = BitcoinLikeAddress::fromPublicKey(xpub, currency, p, _keychainEngine);
                         preferencesEdit = preferencesEdit->putString(cacheKey, address)->putString(fmt::format("address:{}", address), localPath);
                         hasDBChange = true;
                     }
                     res.emplace_back(std::dynamic_pointer_cast<BitcoinLikeAddress>(BitcoinLikeAddress::parse(address, getCurrency(), Option<std::string>(localPath))));
+                }
+            }
+            if (hasDBChange) {
+                preferencesEdit->commit();
+            }
+            return res;
+        }
+
+        std::vector<std::string> CommonBitcoinLikeKeychains::deriveInBulkAddressString(uint32_t from, uint32_t to) {
+            auto currency = getCurrency();
+            std::vector<std::string> res;
+            res.reserve((to - from + 1) * 2);
+            auto preferencesEdit = getPreferences()->edit();
+            bool hasDBChange = false;
+            for (int index = from; index <= to; index++)
+            {
+                for (int iPurpose : {KeyPurpose::RECEIVE, KeyPurpose::CHANGE})
+                {                    
+                    auto localPath = getDerivationScheme()
+                        .setAccountIndex(getAccountIndex())
+                        .setCoinType(currency.bip44CoinType)
+                        .setNode(iPurpose).setAddressIndex(index).getPath().toString();
+                    auto p = getDerivationScheme().getSchemeFrom(DerivationSchemeLevel::NODE).shift(1)
+                        .setAccountIndex(getAccountIndex())
+                        .setCoinType(currency.bip44CoinType)
+                        .setNode(iPurpose).setAddressIndex(index).getPath().toString();
+                    auto cacheKey = fmt::format("path:{}", localPath);
+                    auto address = getPreferences()->getString(cacheKey, "");
+
+                    if (address.empty()) {
+                        auto xpub = iPurpose == KeyPurpose::RECEIVE ? _publicNodeXpub : _internalNodeXpub;
+                        address = BitcoinLikeAddress::fromPublicKey(xpub, currency, p, _keychainEngine);
+                        preferencesEdit = preferencesEdit->putString(cacheKey, address)->putString(fmt::format("address:{}", address), localPath);
+                        hasDBChange = true;
+                    }
+                    res.emplace_back(address);
                 }
             }
             if (hasDBChange) {

--- a/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
+++ b/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
@@ -67,10 +67,11 @@ namespace ledger {
                                      const std::shared_ptr<api::BitcoinLikeExtendedPublicKey> &xpub,
                                      const std::shared_ptr<Preferences> &preferences);
 
-            bool markPathAsUsed(const DerivationPath &path) override;
+            bool markPathAsUsed(const DerivationPath &path, bool needExtendKeychain=true) override;
 
             BitcoinLikeKeychain::Address getFreshAddress(KeyPurpose purpose) override;
             std::vector<BitcoinLikeKeychain::Address> getAllObservableAddresses(uint32_t from, uint32_t to) override;
+            std::vector<std::string> getAllObservableAddressString(uint32_t from, uint32_t to) override;
             std::vector<BitcoinLikeKeychain::Address> getFreshAddresses(KeyPurpose purpose, size_t n) override;
             Option<KeyPurpose> getAddressPurpose(const std::string &address) const override;
             Option<std::string> getAddressDerivationPath(const std::string &address) const override;
@@ -94,6 +95,7 @@ namespace ledger {
 
         private:
             BitcoinLikeKeychain::Address derive(KeyPurpose purpose, off_t index);
+            std::vector<std::string> deriveInBulkAddressString(uint32_t from, uint32_t to);
             std::vector<BitcoinLikeKeychain::Address> deriveInBulk(uint32_t from, uint32_t to);
             void saveState();
             KeychainPersistentState _state;

--- a/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
+++ b/core/src/wallet/bitcoin/keychains/CommonBitcoinLikeKeychains.hpp
@@ -95,8 +95,6 @@ namespace ledger {
 
         private:
             BitcoinLikeKeychain::Address derive(KeyPurpose purpose, off_t index);
-            std::vector<std::string> deriveInBulkAddressString(uint32_t from, uint32_t to);
-            std::vector<BitcoinLikeKeychain::Address> deriveInBulk(uint32_t from, uint32_t to);
             void saveState();
             KeychainPersistentState _state;
             std::shared_ptr<api::BitcoinLikeExtendedPublicKey> _xpub;

--- a/core/src/wallet/bitcoin/synchronizers/BlockchainExplorerAccountSynchronizer.cpp
+++ b/core/src/wallet/bitcoin/synchronizers/BlockchainExplorerAccountSynchronizer.cpp
@@ -149,7 +149,7 @@ namespace ledger {
 
                     for (auto &io : txIo) {
                         if (io.address.hasValue()) {
-                            keychain->markAsUsed(io.address.getValue());
+                            keychain->markAsUsed(io.address.getValue(), false);
                             flag |= BitcoinLikeAccount::FLAG_TRANSACTION_CREATED_SENDING_OPERATION;
                         }
                     }
@@ -157,7 +157,7 @@ namespace ledger {
                 };
                 return markAddress(transaction.inputs) | markAddress(transaction.outputs);
             }
-            return buddy->account->putTransaction(sql, transaction);
+            return buddy->account->putTransaction(sql, transaction, false);
         }
 
         std::shared_ptr<CommonBuddy>

--- a/core/src/wallet/cosmos/keychains/CosmosLikeKeychain.cpp
+++ b/core/src/wallet/cosmos/keychains/CosmosLikeKeychain.cpp
@@ -80,6 +80,10 @@ std::vector<CosmosLikeKeychain::Address> CosmosLikeKeychain::getAllObservableAdd
     return {_address};
 }
 
+std::vector<std::string> CosmosLikeKeychain::getAllObservableAddressString(uint32_t from, uint32_t to) {
+    return { _address->toString() };
+}
+
 std::shared_ptr<CosmosLikeKeychain> CosmosLikeKeychain::restore(
     const DerivationPath &path, const api::Currency &currency, const std::string &restoreKey)
 {

--- a/core/src/wallet/cosmos/keychains/CosmosLikeKeychain.hpp
+++ b/core/src/wallet/cosmos/keychains/CosmosLikeKeychain.hpp
@@ -56,6 +56,7 @@ class CosmosLikeKeychain : public api::Keychain {
     std::string getRestoreKey() const;
     const std::vector<uint8_t> &getPublicKey() const;
     std::vector<Address> getAllObservableAddresses(uint32_t from, uint32_t to);
+    std::vector<std::string> getAllObservableAddressString(uint32_t from, uint32_t to);
 
     static std::shared_ptr<CosmosLikeKeychain> restore(
         const DerivationPath &path, const api::Currency &currency, const std::string &restoreKey);

--- a/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.cpp
+++ b/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.cpp
@@ -125,11 +125,13 @@ namespace ledger {
 
         std::vector<EthereumLikeKeychain::Address>
         EthereumLikeKeychain::getAllObservableAddresses(uint32_t from, uint32_t to) {
-            std::vector<EthereumLikeKeychain::Address> result;
-            result.push_back(derive());
-            return result;
+            return { derive() };
         }
 
+        std::vector<std::string>
+            EthereumLikeKeychain::getAllObservableAddressString(uint32_t from, uint32_t to) {
+            return { derive()->toString() };
+        }
 
         std::shared_ptr<api::EthereumLikeExtendedPublicKey> EthereumLikeKeychain::getExtendedPublicKey() const {
             return _xpub;

--- a/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.hpp
+++ b/core/src/wallet/ethereum/keychains/EthereumLikeKeychain.hpp
@@ -71,6 +71,7 @@ namespace ledger {
                                  const std::string &accountAddress,
                                  const std::shared_ptr<Preferences>& preferences);
             std::vector<Address> getAllObservableAddresses(uint32_t from, uint32_t to);
+            std::vector<std::string> getAllObservableAddressString(uint32_t from, uint32_t to);
             Address getAddress() const;
             Option<std::string> getAddressDerivationPath(const std::string &address) const ;
             std::shared_ptr<api::EthereumLikeExtendedPublicKey> getExtendedPublicKey() const;
@@ -90,8 +91,7 @@ namespace ledger {
             bool contains(const std::string& address) const ;
             int32_t getOutputSizeAsSignedTxInput() const ;
             std::shared_ptr<Preferences> getPreferences() const;
-
-        protected:
+        protected:            
             DerivationScheme& getDerivationScheme();
 
         private:

--- a/core/src/wallet/ripple/keychains/RippleLikeKeychain.cpp
+++ b/core/src/wallet/ripple/keychains/RippleLikeKeychain.cpp
@@ -126,11 +126,12 @@ namespace ledger {
 
         std::vector<RippleLikeKeychain::Address>
         RippleLikeKeychain::getAllObservableAddresses(uint32_t from, uint32_t to) {
-            std::vector<RippleLikeKeychain::Address> result;
-            result.push_back(derive());
-            return result;
+            return {derive()};
         }
 
+        std::vector<std::string> RippleLikeKeychain::getAllObservableAddressString(uint32_t from, uint32_t to) {
+            return {derive()->toString()};
+        }
 
         std::shared_ptr<api::RippleLikeExtendedPublicKey> RippleLikeKeychain::getExtendedPublicKey() const {
             return _xpub;

--- a/core/src/wallet/ripple/keychains/RippleLikeKeychain.h
+++ b/core/src/wallet/ripple/keychains/RippleLikeKeychain.h
@@ -75,6 +75,8 @@ namespace ledger {
 
             std::vector<Address> getAllObservableAddresses(uint32_t from, uint32_t to);
 
+            std::vector<std::string> getAllObservableAddressString(uint32_t from, uint32_t to);
+
             Address getAddress() const;
 
             Option<std::string> getAddressDerivationPath(const std::string &address) const;
@@ -103,7 +105,8 @@ namespace ledger {
             int32_t getOutputSizeAsSignedTxInput() const;
 
             std::shared_ptr<Preferences> getPreferences() const;
-        protected:
+
+        protected:            
 
             DerivationScheme &getDerivationScheme();
 

--- a/core/src/wallet/tezos/keychains/TezosLikeKeychain.cpp
+++ b/core/src/wallet/tezos/keychains/TezosLikeKeychain.cpp
@@ -72,7 +72,11 @@ namespace ledger {
 
         std::vector <TezosLikeKeychain::Address>
         TezosLikeKeychain::getAllObservableAddresses(uint32_t from, uint32_t to) {
-            return std::vector<TezosLikeKeychain::Address>{getAddressFromPublicKey()};
+            return {getAddressFromPublicKey()};
+        }
+
+        std::vector <std::string> TezosLikeKeychain::getAllObservableAddressString(uint32_t from, uint32_t to) {
+            return {getAddressFromPublicKey()->toString()};
         }
 
         std::string TezosLikeKeychain::getRestoreKey() const {

--- a/core/src/wallet/tezos/keychains/TezosLikeKeychain.h
+++ b/core/src/wallet/tezos/keychains/TezosLikeKeychain.h
@@ -60,6 +60,8 @@ namespace ledger {
 
             std::vector <Address> getAllObservableAddresses(uint32_t from, uint32_t to);
 
+            std::vector<std::string> getAllObservableAddressString(uint32_t from, uint32_t to);
+
             Address getAddress() const;
 
             const api::TezosLikeNetworkParameters &getNetworkParameters() const;
@@ -75,6 +77,7 @@ namespace ledger {
             bool contains(const std::string &address) const;
 
             std::shared_ptr <Preferences> getPreferences() const;
+
         protected:
 
         private:


### PR DESCRIPTION
The "keychain_perf_optimisation" branch includes all the change of "fix_sync_perf_bottleneck" and "bitcoin_sync_fix"
So this PR is after https://github.com/LedgerHQ/lib-ledger-core/pull/672 and https://github.com/LedgerHQ/lib-ledger-core/pull/677

1. Extend the keychain before the sync, so that we get all addresses at first pass and save them in memory. This can improve the sync performance.
2. some little optimisation for regex.
3. We don't need to always construct bitcoinLikeAddress object. I add a method that just returns address string to improve performance.